### PR TITLE
fix: switch from BootCDN to Zstatic.net

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,13 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Linux Kernel Patch Statistic among Universities</title>
 
-    <script src="https://cdn.bootcdn.net/ajax/libs/react/18.2.0/umd/react.development.min.js"></script>
-    <script src="https://cdn.bootcdn.net/ajax/libs/react-dom/18.2.0/umd/react-dom.development.min.js"></script>
-    <script src="https://cdn.bootcdn.net/ajax/libs/babel-standalone/7.22.17/babel.min.js"></script>
-    <script src="https://cdn.bootcdn.net/ajax/libs/dayjs/1.11.9/dayjs.min.js"></script>
+    <script src="https://s4.zstatic.net/ajax/libs/react/18.2.0/umd/react.development.min.js" integrity="sha384-2Lh7Q+QSdCvoe0sllT5jFErR9aFIWJHFufzuseDyLsJn9a5m2YqQHhCz0NpGNFIB" crossorigin="anonymous"></script>
+    <script src="https://s4.zstatic.net/ajax/libs/react-dom/18.2.0/umd/react-dom.development.min.js" integrity="sha384-UQ4ATYmjYZlBA1kyQlDkeJj4TdyVKTmKtUnyVEDVKvPr7GOISK9tfDyxTIvpDFhc" crossorigin="anonymous"></script>
+    <script src="https://s4.zstatic.net/ajax/libs/babel-standalone/7.22.17/babel.min.js" integrity="sha384-E9gF5bp/9ap5fWKPvScT2xn3qYLXBVuViOUYO1AritUY8zlH3ISflL2d7NvJfg/s" crossorigin="anonymous"></script>
+    <script src="https://s4.zstatic.net/ajax/libs/dayjs/1.11.9/dayjs.min.js" integrity="sha384-ok2ureoh4h8/yzfhscH9aGBd1IrWT0jPFG7JF7dbo+uFAQCn3jc6nY1AYH5y6hhv" crossorigin="anonymous"></script>
 
-    <script src="https://cdn.bootcdn.net/ajax/libs/antd/5.9.0/antd.min.js"></script>
-    <link href="https://cdn.bootcdn.net/ajax/libs/antd/5.9.0/reset.min.css" rel="stylesheet">
+    <script src="https://s4.zstatic.net/ajax/libs/antd/5.9.0/antd.min.js" integrity="sha384-PYHnf42vhdyuGieCUjW1qCt8qpvsUnbRGdHnKnNhdxj0g5P+fljo+JmM4NYV0FDD" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://s4.zstatic.net/ajax/libs/antd/5.9.0/reset.min.css" integrity="sha384-iqyoCPXvqh7OcpFMoeqEPDFuAYAXgbIzXw++z0KY2NBDjkvq0siOCcRIKwu892Ca" crossorigin="anonymous">
 
 </head>
 


### PR DESCRIPTION
Closes #13

使用 https://srihash.zstatic.net/ 生成 integrity