### PR TITLE
fix: adjust the layout of metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,6 +155,9 @@
                 return data
             }, [chinaOnly, data])
 
+            const screens = antd.Grid.useBreakpoint();
+            const columnMetadata = screens.lg ? 4 : screens.md ? 3 : screens.sm ? 2 : 1;
+
             return (
                 <antd.Spin spinning={loading}>
                     <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
@@ -165,7 +168,7 @@
                     </div>
                     <div>
                         {
-                            meta && <antd.Descriptions>
+                            meta && <antd.Descriptions column={columnMetadata}>
                                 <antd.Descriptions.Item label="Last update">{meta.update ? dayjs(meta.update).format("YYYY-MM-DD HH:mm") : "N/A"}</antd.Descriptions.Item>
                                 <antd.Descriptions.Item label="Repo">{meta.repo}</antd.Descriptions.Item>
                                 <antd.Descriptions.Item label="Branch">{meta.branch}</antd.Descriptions.Item>


### PR DESCRIPTION
Aligns the four metadata items on a single row on desktop, with graceful wrapping on small screens.

<img width="2553" height="893" alt="image" src="https://github.com/user-attachments/assets/f59016a9-923d-4b57-a5c7-1df6f1da5849" />

<img width="934" height="713" alt="image" src="https://github.com/user-attachments/assets/0739cbd6-e866-4390-87af-fd6cd1f8db92" />

See #49

Supersedes #50 because the contributor has not responded for a long time.