### PR TITLE
Implement caching forAdd cache for Linux kernel clone step

### DIFF
--- a/.github/workflows/update-page.yaml
+++ b/.github/workflows/update-page.yaml
@@ -12,16 +12,35 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: master
-          fetch-depth: 0
-      - name: clone kernel
-        uses: actions/checkout@v4
-        with:
-          repository: torvalds/linux
-          path: linux
-          fetch-depth: 0
+     - uses: actions/checkout@v4
+       with:
+        ref: master
+        fetch-depth: 0
+
+     - name: Cache Linux kernel repository
+       id: cache-linux-repo
+       uses: actions/cache@v4
+       with:
+        path: linux
+        key: linux-kernel-repo-${{ github.run_id }}
+        restore-keys: |
+         linux-kernel-repo-
+
+      - name: Clone or update Linux kernel repository
+        run: |
+         if [ -d "linux/.git" ]; then
+           echo "Cache hit, fetching latest changes..."
+           cd linux
+           git fetch --all --prune
+           git checkout master
+           git reset --hard origin/master
+         else
+           echo "No cache found, cloning full repository..."
+           git clone --mirror https://github.com/torvalds/linux.git linux/.git
+           cd linux
+           git config --bool core.bare false
+           git checkout master
+          fi
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
This PR adds a cache mechanism for the Linux kernel repository clone step in the GitHub Actions workflow.

- Use `actions/cache@v4` to cache the `.git` directory.
- If cache exists, run `git fetch` to only pull incremental changes.
- Otherwise, perform a full mirror clone.

Closes #55.