### PR TITLE
ci: use single-branch clone for kernel cache to fix fetch conflict

### DIFF
--- a/.github/workflows/update-page.yaml
+++ b/.github/workflows/update-page.yaml
@@ -22,24 +22,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: linux
-          key: linux-kernel-repo-${{ github.run_id }}
+          key: linux-kernel-repo-v2-${{ github.run_id }}
           restore-keys: |
-            linux-kernel-repo-
+            linux-kernel-repo-v2-
 
       - name: Clone or update Linux kernel repository
         run: |
           if [ -d "linux/.git" ]; then
             echo "Cache hit, fetching latest changes..."
-            cd linux
-            git fetch --all --prune
-            git checkout master
-            git reset --hard origin/master
+            git -C linux fetch --prune
+            git -C linux reset --hard origin/master
           else
             echo "No cache found, cloning full repository..."
-            git clone --mirror https://github.com/torvalds/linux.git linux/.git
-            cd linux
-            git config --bool core.bare false
-            git checkout master
+            git clone --single-branch --branch master https://github.com/torvalds/linux.git linux
           fi
 
       - name: Setup Python


### PR DESCRIPTION
The mirror clone configured remote.origin with a +refs/*:refs/* refspec, so on cache hits `git fetch --all` tried to update refs/heads/master — the checked-out branch — and git refused.

Switch to a plain single-branch clone of master so fetch only updates refs/remotes/origin/master. Bump the cache key prefix to v2 so stale mirror-configured caches are not restored.